### PR TITLE
Fix for issue#34 incorrect timestamp publishing

### DIFF
--- a/influx/influx.go
+++ b/influx/influx.go
@@ -141,7 +141,6 @@ func (f *influxPublisher) Publish(contentType string, content []byte, config map
 		tags := map[string]string{"source": m.Source()}
 		if m.Labels_ != nil {
 			for _, label := range m.Labels_ {
-				tags[label.Name] = m.Namespace()[label.Index]
 				ns = str.Filter(
 					ns,
 					func(n string) bool {
@@ -155,7 +154,7 @@ func (f *influxPublisher) Publish(contentType string, content []byte, config map
 		}
 		pts[i] = client.Point{
 			Measurement: strings.Join(ns, "/"),
-			Time:        m.Timestamp(),
+			Time:        m.Timestamp().Unix(),
 			Tags:        tags,
 			Fields: map[string]interface{}{
 				"value": m.Data(),


### PR DESCRIPTION
Also removed adding labels to tags. It resulted in adding unnecessary column names with label.Name in InfluxDB measurements.