### PR TITLE
Add dynamic metric tests

### DIFF
--- a/influx/influx_large_test.go
+++ b/influx/influx_large_test.go
@@ -127,5 +127,28 @@ func TestInfluxPublish(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
+		Convey("Publish dynamic metrics", func() {
+			dynamicNS1 := core.NewNamespace("foo").
+				AddDynamicElement("dynamic", "dynamic elem").
+				AddStaticElement("bar")
+			dynamicNS2 := core.NewNamespace("foo").
+				AddDynamicElement("dynamic_one", "dynamic element one").
+				AddDynamicElement("dynamic_two", "dynamic element two").
+				AddStaticElement("baz")
+
+			dynamicNS1[1].Value = "fooval"
+			dynamicNS2[1].Value = "barval"
+			dynamicNS2[2].Value = "bazval"
+
+			metrics := []plugin.MetricType{
+				*plugin.NewMetricType(dynamicNS1, time.Now(), tags, "", 123),
+				*plugin.NewMetricType(dynamicNS2, time.Now(), tags, "", 456),
+			}
+			buf.Reset()
+			enc := gob.NewEncoder(&buf)
+			enc.Encode(metrics)
+			err := ip.Publish(plugin.SnapGOBContentType, buf.Bytes(), *cfg)
+			So(err, ShouldBeNil)
+		})
 	})
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -75,7 +75,7 @@ _go_test() {
   do
     if [[ -z ${go_cover+x} ]]; then
       _debug "running go test with cover in ${dir}"
-      go test --tags="${TEST_TYPE}" -covermode=count -coverprofile="${dir}/profile.tmp" "${dir}"
+      go test -v --tags="${TEST_TYPE}" -covermode=count -coverprofile="${dir}/profile.tmp" "${dir}"
       if [ -f "${dir}/profile.tmp" ]; then
         tail -n +2 "${dir}/profile.tmp" >> profile.cov
         rm "${dir}/profile.tmp"

--- a/scripts/large_local.sh
+++ b/scripts/large_local.sh
@@ -34,7 +34,8 @@ docker_id=$(docker run -d -e PRE_CREATE_DB="test" -p 8083:8083 -p 8086:8086 --ex
 _go_get github.com/smartystreets/goconvey/convey
 _go_get github.com/smartystreets/assertions
 
-export SNAP_INFLUXDB_HOST=127.0.0.1
+set +e  # don't bail out of the script without stopping/removing the docker container
+export SNAP_INFLUXDB_HOST=${SNAP_INFLUXDB_HOST:-127.0.0.1}
 _go_test
 _debug "stopping docker image: ${docker_id}"
 docker stop "${docker_id}" > /dev/null


### PR DESCRIPTION
Prior to this commit, no large tests existed for testing dynamic metrics. There's some code in `Publish()` that replaces dynamic namespace elements with tags, and this should also be covered.

This commit adds a few basic tests to `influx_large_test.go`, specifically testing metrics that contain one and two dynamic elements. It also increases verbosity so that the person / system running the test captures the dynamic element name and value in the test output.