### PR TITLE
Handle multiple dynamic elements per metric

### DIFF
--- a/influx/influx.go
+++ b/influx/influx.go
@@ -162,10 +162,16 @@ func (f *influxPublisher) Publish(contentType string, content []byte, config map
 
 		isDynamic, indexes := m.Namespace().IsDynamic()
 		if isDynamic {
-			for _, i := range indexes {
-				// Removing "data"" from the namespace and create a tag for it
-				ns = append(ns[:i], ns[i+1:]...)
-				tags[m.Namespace()[i].Name] = m.Namespace()[i].Value
+			for i, j := range indexes {
+				// The second return value from IsDynamic(), in this case `indexes`, is the index of
+				// the dynamic element in the unmodified namespace. However, here we're deleting
+				// elements, which is problematic when the number of dynamic elements in a namespace is
+				// greater than 1. Therefore, we subtract i (the loop iteration) from j
+				// (the original index) to compensate.
+				//
+				// Remove "data" from the namespace and create a tag for it
+				ns = append(ns[:j-i], ns[j-i+1:]...)
+				tags[m.Namespace()[j].Name] = m.Namespace()[j].Value
 			}
 		}
 

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	name                      = "influx"
-	version                   = 12
+	version                   = 13
 	pluginType                = plugin.PublisherPluginType
 	maxInt64                  = ^uint64(0) / 2
 	defaultTimestampPrecision = "s"

--- a/influx/influx_large_test.go
+++ b/influx/influx_large_test.go
@@ -127,5 +127,28 @@ func TestInfluxPublish(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
+		Convey("Publish dynamic metrics", func() {
+			dynamicNS1 := core.NewNamespace("foo").
+				AddDynamicElement("dynamic", "dynamic elem").
+				AddStaticElement("bar")
+			dynamicNS2 := core.NewNamespace("foo").
+				AddDynamicElement("dynamic_one", "dynamic element one").
+				AddDynamicElement("dynamic_two", "dynamic element two").
+				AddStaticElement("baz")
+
+			dynamicNS1[1].Value = "fooval"
+			dynamicNS2[1].Value = "barval"
+			dynamicNS2[2].Value = "bazval"
+
+			metrics := []plugin.MetricType{
+				*plugin.NewMetricType(dynamicNS1, time.Now(), tags, "", 123),
+				*plugin.NewMetricType(dynamicNS2, time.Now(), tags, "", 456),
+			}
+			buf.Reset()
+			enc := gob.NewEncoder(&buf)
+			enc.Encode(metrics)
+			err := ip.Publish(plugin.SnapGOBContentType, buf.Bytes(), *cfg)
+			So(err, ShouldBeNil)
+		})
 	})
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -75,7 +75,7 @@ _go_test() {
   do
     if [[ -z ${go_cover+x} ]]; then
       _debug "running go test with cover in ${dir}"
-      go test --tags="${TEST_TYPE}" -covermode=count -coverprofile="${dir}/profile.tmp" "${dir}"
+      go test -v --tags="${TEST_TYPE}" -covermode=count -coverprofile="${dir}/profile.tmp" "${dir}"
       if [ -f "${dir}/profile.tmp" ]; then
         tail -n +2 "${dir}/profile.tmp" >> profile.cov
         rm "${dir}/profile.tmp"

--- a/scripts/large_local.sh
+++ b/scripts/large_local.sh
@@ -34,7 +34,8 @@ docker_id=$(docker run -d -e PRE_CREATE_DB="test" -p 8083:8083 -p 8086:8086 --ex
 _go_get github.com/smartystreets/goconvey/convey
 _go_get github.com/smartystreets/assertions
 
-export SNAP_INFLUXDB_HOST=127.0.0.1
+set +e  # don't bail out of the script without stopping/removing the docker container
+export SNAP_INFLUXDB_HOST=${SNAP_INFLUXDB_HOST:-127.0.0.1}
 _go_test
 _debug "stopping docker image: ${docker_id}"
 docker stop "${docker_id}" > /dev/null


### PR DESCRIPTION
Prior to this commit, `Publish()` could only handle a single dynamic element per namespace. If a second element was introduced, `Publish()` would still use the original index, despite the array now being one element smaller.

This commit now tracks which iteration of the loop we're on, beginning with 0, and subtracts that from the original index to compensate:

```golang
ns = append(ns[:j-i], ns[j-i+1:]...)
```

In running `./scripts/large_local.sh`, one can now observe the proper behavior with the included tests:

```
DEBU[0005] publishing metrics    batch-points=[foo/bar,dynamic=fooval,zone=red value=123i
1465684461717118193 foo/baz,dynamic_one=barval,dynamic_two=bazval,zone=red value=456i
1465684461717119363] plugin-name=influx plugin-type=publisher plugin-version=12
```