### PR TITLE
Fixed bug which prevented reusing existing connections from connectio…

### DIFF
--- a/influx/influx.go
+++ b/influx/influx.go
@@ -332,7 +332,7 @@ func selectClientConnection(config map[string]ctypes.ConfigValue) (*clientConnec
 	key := connectionKey(u, user, db)
 
 	// Do we have a existing client?
-	if connPool[u.String()] == nil {
+	if connPool[key] == nil {
 		// create one and add to the pool
 		con, err := client.NewHTTPClient(client.HTTPConfig{
 			Addr:     u.String(),


### PR DESCRIPTION
…n pool thus causing multiplication of unused connections and "socket: too many open files" OS-level error; Just changed connectionPool key for connection check from u.String() to composite ConnectionKey(u,user,db) key which was used everywhere else