### PR TITLE
Fixed  SNAP_VERSION and allowed for snapctl to download before task was created

### DIFF
--- a/examples/tasks/docker-compose.yml
+++ b/examples/tasks/docker-compose.yml
@@ -2,9 +2,9 @@ version: '2'
 services:
   main:
     container_name: runner
-    image: intelsdi/snap:latest_alpine
+    image: intelsdi/snap:alpine
     environment:
-      - SNAP_VERSION="latest"
+     - SNAP_VERSION=latest
     volumes:
       - ${PLUGIN_SRC}:/snap-plugin-publisher-influxdb          
     links:

--- a/examples/tasks/mock-influxdb.sh
+++ b/examples/tasks/mock-influxdb.sh
@@ -23,10 +23,34 @@ _info "Get latest plugins"
 _info "creating database"
 curl -i -XPOST http://influxdb:8086/query --data-urlencode "q=CREATE DATABASE test"
 
-_info "loading plugins"
-snapctl plugin load "${PLUGIN_PATH}/snap-plugin-publisher-mock-file"
-snapctl plugin load "${PLUGIN_PATH}/snap-plugin-collector-mock2"
-snapctl plugin load "${PLUGIN_PATH}/snap-plugin-publisher-influxdb" 
+SNAP_FLAG=0
 
-_info "creating and starting a task"
-snapctl task create -t "${__dir}/task-mock-influxdb.yml" 
+# this block will wait check if snapctl and snapd are loaded before the plugins are loaded and the task is started
+ for i in `seq 1 5`; do
+             if [[ -f /usr/local/bin/snapctl && -f /usr/local/bin/snapd ]];
+                then
+
+                    _info "loading plugins"
+                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-publisher-mock-file"
+                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-collector-mock2"
+                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-publisher-influxdb" 
+
+                    _info "creating and starting a task"
+                    snapctl task create -t "${__dir}/task-mock-influxdb.yml" 
+
+                    SNAP_FLAG=1
+
+                    break
+             fi 
+        
+        _info "snapctl and/or snapd are unavailable, sleeping for 3 seconds" 
+        sleep 3
+done 
+
+
+# check if snapctl/snapd have loaded
+if [ $SNAP_FLAG -eq 0 ]
+    then
+     echo "Could not load snapctl or snapd"
+     exit 1
+fi

--- a/scripts/config/influxdb-deployment.yml
+++ b/scripts/config/influxdb-deployment.yml
@@ -18,7 +18,7 @@ spec:
               - containerPort: 8083
               - containerPort: 8086
             - name: main
-              image: intelsdi/snap:latest_alpine
+              image: intelsdi/snap:alpine
               env:
                 - name: SNAP_VERSION
                   value: "latest"


### PR DESCRIPTION
The Alpine container was not loading snap because of an error parsing the `"` character in the SNAP_VERSION section of the docker-compose file.  I have removed the quotes to fix the error. 

There was also an issue where snapctl was not loaded before attempting to create tasks. I added a loop in the `mock-influxdb.sh` script to wait for snapctl before loading plugins/starting tasks.  