### PR TITLE
Renamed plugin package and plugin name to influxdb

### DIFF
--- a/examples/tasks/task-mock-influxdb.yml
+++ b/examples/tasks/task-mock-influxdb.yml
@@ -16,7 +16,7 @@
           password: "secret"          
       publish: 
         - 
-          plugin_name: "influx"
+          plugin_name: "influxdb"
           config: 
              host: "influxdb"
              port: 8086

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package influx
+package influxdb
 
 import (
 	"bytes"

--- a/influxdb/influxdb_medium_test.go
+++ b/influxdb/influxdb_medium_test.go
@@ -18,7 +18,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package influx
+package influxdb
 
 import (
 	"bytes"

--- a/influxdb/influxdb_small_test.go
+++ b/influxdb/influxdb_small_test.go
@@ -18,7 +18,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package influx
+package influxdb
 
 import (
 	"testing"

--- a/main.go
+++ b/main.go
@@ -22,11 +22,11 @@ package main
 import (
 	"os"
 
-	"github.com/intelsdi-x/snap-plugin-publisher-influxdb/influx"
+	"github.com/intelsdi-x/snap-plugin-publisher-influxdb/influxdb"
 	"github.com/intelsdi-x/snap/control/plugin"
 )
 
 func main() {
-	meta := influx.Meta()
-	plugin.Start(meta, influx.NewInfluxPublisher(), os.Args[1])
+	meta := influxdb.Meta()
+	plugin.Start(meta, influxdb.NewInfluxPublisher(), os.Args[1])
 }


### PR DESCRIPTION
Fixes #66 

Tests done:
- Build, small, medium.

Important information:
- Large test won't work until it deploys the new binary with the replaced name.