### PR TITLE
Add retention config option

### DIFF
--- a/examples/tasks/task-mock-influxdb.yml
+++ b/examples/tasks/task-mock-influxdb.yml
@@ -21,5 +21,6 @@
              host: "influxdb"
              port: 8086
              database: "test"
+             retention: "autogen"
              user: "admin"
              password: "admin"

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -102,6 +102,11 @@ func (f *influxPublisher) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	r5.Description = "Influxdb password"
 	config.Add(r4)
 
+	r6, err := cpolicy.NewStringRule("retention", false, "autogen")
+	handleErr(err)
+	r6.Description = "Influxdb retention policy"
+	config.Add(r6)
+
 	cp.Add([]string{""}, config)
 	return cp, nil
 }
@@ -152,7 +157,7 @@ func (f *influxPublisher) Publish(contentType string, content []byte, config map
 	//Set up batch points
 	bps, _ := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:        config["database"].(ctypes.ConfigValueStr).Value,
-		RetentionPolicy: "default",
+		RetentionPolicy: config["retention"].(ctypes.ConfigValueStr).Value,
 		Precision:       defaultTimestampPrecision,
 	})
 

--- a/influxdb/influxdb_medium_test.go
+++ b/influxdb/influxdb_medium_test.go
@@ -25,6 +25,7 @@ import (
 	"encoding/gob"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,12 +58,20 @@ func TestInfluxPublish(t *testing.T) {
 
 	Convey("snap plugin InfluxDB integration testing with Influx", t, func() {
 		var buf bytes.Buffer
+		var retention string
+
+		if strings.HasPrefix(os.Getenv("INFLUXDB_VERSION"), "0.") {
+			retention = "default"
+		} else {
+			retention = "autogen"
+		}
 
 		config["host"] = ctypes.ConfigValueStr{Value: os.Getenv("SNAP_INFLUXDB_HOST")}
 		config["port"] = ctypes.ConfigValueInt{Value: 8086}
 		config["user"] = ctypes.ConfigValueStr{Value: "root"}
 		config["password"] = ctypes.ConfigValueStr{Value: "root"}
 		config["database"] = ctypes.ConfigValueStr{Value: "test"}
+		config["retention"] = ctypes.ConfigValueStr{Value: retention}
 		config["debug"] = ctypes.ConfigValueBool{Value: false}
 		config["log-level"] = ctypes.ConfigValueStr{Value: "debug"}
 

--- a/influxdb/influxdb_small_test.go
+++ b/influxdb/influxdb_small_test.go
@@ -62,6 +62,7 @@ func TestInfluxDBPlugin(t *testing.T) {
 			testConfig["user"] = ctypes.ConfigValueStr{Value: "root"}
 			testConfig["password"] = ctypes.ConfigValueStr{Value: "root"}
 			testConfig["database"] = ctypes.ConfigValueStr{Value: "test"}
+			testConfig["retention"] = ctypes.ConfigValueStr{Value: "testretention"}
 			cfg, errs := configPolicy.Get([]string{""}).Process(testConfig)
 			Convey("So config policy should process testConfig and return a config", func() {
 				So(cfg, ShouldNotBeNil)


### PR DESCRIPTION
Fixes #72 #77 

Summary of changes:
- Add retention configuration option
- Updated tests to add this new config option

How to verify it:
- Run tests against InfluxDB > 1.0 and it should work as well

Testing done:
- Tests ran with 0.13 successfully
- Tests ran with 1.0 successfully