### PR TITLE
Password config option was not used

### DIFF
--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -100,7 +100,7 @@ func (f *influxPublisher) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	r5, err := cpolicy.NewStringRule("password", true)
 	handleErr(err)
 	r5.Description = "Influxdb password"
-	config.Add(r4)
+	config.Add(r5)
 
 	cp.Add([]string{""}, config)
 	return cp, nil


### PR DESCRIPTION
Fixes #86 

Summary of changes:
- Fix typo that would not use the username instead of the password to connect to InfluxDB

How to verify it:
- Connect to a DB where `user` != `password` and it should work

Testing done:
- Tested it against my setup

Note that it always works in the test suite because the username == password and I couldn't find a way to specify the password via the environment in the InfluxDB docker image or to integrate easily with the code to then execute a query that would change the password.