### PR TITLE
Add support for HTTPS and invalid certificate flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,22 @@ This builds the plugin in `/build/rootfs/`
 `export SNAP_PATH=$GOPATH/src/github.com/intelsdi-x/snap/build`
 
 ## Documentation
-<< @TODO
+
+The plugin expects you to provide the following parameters:
+ - `host`
+ - `port`
+ - `database`
+ - `user`
+ - `password`
+
+You can also set the following options if needed:
+ - `https` defaults to `false` (boolean). Set to true to connect to InfluxDB via HTTPS.
+ - `skip-verify` defaults to `false` (boolean). Set to true to complain if the certificate used is not issued by a trusted CA.
 
 ### Examples
-<< @TODO
+
+See [examples/tasks](https://github.com/intelsdi-x/snap-plugin-publisher-influxdb/tree/master/examples/tasks) folder for examples
+
 
 ### Roadmap
 

--- a/examples/tasks/task-mock-influxdb.yml
+++ b/examples/tasks/task-mock-influxdb.yml
@@ -24,3 +24,5 @@
              retention: "autogen"
              user: "admin"
              password: "admin"
+             https: true
+             skip-verify: false

--- a/influxdb/influxdb_medium_test.go
+++ b/influxdb/influxdb_medium_test.go
@@ -68,6 +68,8 @@ func TestInfluxPublish(t *testing.T) {
 
 		config["host"] = ctypes.ConfigValueStr{Value: os.Getenv("SNAP_INFLUXDB_HOST")}
 		config["port"] = ctypes.ConfigValueInt{Value: 8086}
+		config["https"] = ctypes.ConfigValueBool{Value: false}
+		config["skip-verify"] = ctypes.ConfigValueBool{Value: false}
 		config["user"] = ctypes.ConfigValueStr{Value: "root"}
 		config["password"] = ctypes.ConfigValueStr{Value: "root"}
 		config["database"] = ctypes.ConfigValueStr{Value: "test"}

--- a/influxdb/influxdb_small_test.go
+++ b/influxdb/influxdb_small_test.go
@@ -59,6 +59,8 @@ func TestInfluxDBPlugin(t *testing.T) {
 			testConfig := make(map[string]ctypes.ConfigValue)
 			testConfig["host"] = ctypes.ConfigValueStr{Value: "localhost"}
 			testConfig["port"] = ctypes.ConfigValueInt{Value: 8086}
+			testConfig["https"] = ctypes.ConfigValueBool{Value: false}
+			testConfig["skip-verify"] = ctypes.ConfigValueBool{Value: false}
 			testConfig["user"] = ctypes.ConfigValueStr{Value: "root"}
 			testConfig["password"] = ctypes.ConfigValueStr{Value: "root"}
 			testConfig["database"] = ctypes.ConfigValueStr{Value: "test"}


### PR DESCRIPTION
Fixes #88 

Summary of changes:
- Add `https` boolean flag to connect to HTTPS InfluxDB
- Add `skip-verify` boolean flag to skip certificate verification when using HTTPS

How to verify it:
- Connect to a HTTPS enabled InfluxDB 

Testing done:
- Test suite ran OK with defaults for backward compatibility
- InfluxDB container for tests doesn't support HTTPS so validated against an existing local setup
