### PR TITLE
Renamed snapd to snapteld in a comment, corrected a comment

### DIFF
--- a/examples/tasks/mock-influxdb.sh
+++ b/examples/tasks/mock-influxdb.sh
@@ -41,7 +41,7 @@ SNAP_FLAG=0
                     break
              fi 
         
-        _info "snaptel and/or snapteld are unavailable, sleeping for 3 seconds" 
+        _info "snaptel and/or snapteld are unavailable, sleeping for 10 seconds"
         sleep 10
 done 
 

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -350,7 +350,7 @@ func selectClientConnection(config map[string]ctypes.ConfigValue) (*clientConnec
 		return nil, err
 	}
 
-	// Pool changes need to be safe (read & write) since the plugin can be called concurrently by snapd.
+	// Pool changes need to be safe (read & write) since the plugin can be called concurrently by snapteld.
 	m.Lock()
 	defer m.Unlock()
 


### PR DESCRIPTION

Summary of changes:
- Renamed snapd/snapctl to snapteld/snaptel in README and comment
