### PR TITLE
Adds support for timestamp precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The plugin expects you to provide the following parameters:
 You can also set the following options if needed:
  - `https` defaults to `false` (boolean). Set to true to connect to InfluxDB via HTTPS.
  - `skip-verify` defaults to `false` (boolean). Set to true to complain if the certificate used is not issued by a trusted CA.
+ - `precision` defaults to `s` (string). The value can be changed to any of the following: n,u,ms,s,m,h. This will determine the precision of timestamps.
 
 ### Examples
 

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -38,11 +38,10 @@ import (
 )
 
 const (
-	name                      = "influxdb"
-	version                   = 16
-	pluginType                = plugin.PublisherPluginType
-	maxInt64                  = ^uint64(0) / 2
-	defaultTimestampPrecision = "s"
+	name       = "influxdb"
+	version    = 16
+	pluginType = plugin.PublisherPluginType
+	maxInt64   = ^uint64(0) / 2
 )
 
 var (
@@ -117,6 +116,11 @@ func (f *influxPublisher) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	r8.Description = "Influxdb HTTPS Skip certificate verification"
 	config.Add(r8)
 
+	r9, err := cpolicy.NewStringRule("precision", false, "s")
+	handleErr(err)
+	r9.Description = "Influxdb timestamp precision"
+	config.Add(r9)
+
 	cp.Add([]string{""}, config)
 	return cp, nil
 }
@@ -168,7 +172,7 @@ func (f *influxPublisher) Publish(contentType string, content []byte, config map
 	bps, _ := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:        config["database"].(ctypes.ConfigValueStr).Value,
 		RetentionPolicy: config["retention"].(ctypes.ConfigValueStr).Value,
-		Precision:       defaultTimestampPrecision,
+		Precision:       config["precision"].(ctypes.ConfigValueStr).Value,
 	})
 
 	for _, m := range metrics {

--- a/influxdb/influxdb_medium_test.go
+++ b/influxdb/influxdb_medium_test.go
@@ -76,6 +76,7 @@ func TestInfluxPublish(t *testing.T) {
 		config["retention"] = ctypes.ConfigValueStr{Value: retention}
 		config["debug"] = ctypes.ConfigValueBool{Value: false}
 		config["log-level"] = ctypes.ConfigValueStr{Value: "debug"}
+		config["precison"] = ctypes.ConfigValueStr{Value: "s"}
 
 		ip := NewInfluxPublisher()
 		cp, _ := ip.GetConfigPolicy()

--- a/influxdb/influxdb_small_test.go
+++ b/influxdb/influxdb_small_test.go
@@ -65,6 +65,7 @@ func TestInfluxDBPlugin(t *testing.T) {
 			testConfig["password"] = ctypes.ConfigValueStr{Value: "root"}
 			testConfig["database"] = ctypes.ConfigValueStr{Value: "test"}
 			testConfig["retention"] = ctypes.ConfigValueStr{Value: "testretention"}
+			testConfig["precison"] = ctypes.ConfigValueStr{Value: "s"}
 			cfg, errs := configPolicy.Get([]string{""}).Process(testConfig)
 			Convey("So config policy should process testConfig and return a config", func() {
 				So(cfg, ShouldNotBeNil)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #101  

Summary of changes:
- Adds timestamp precision as a configurable option. Default value is set to `s` precision.
- Updates README with optional setting.

How to verify it:
- Run a task with precision outside of `s` and check database contents.

Testing done:
- Currently running task at `ms` precision for my own project. Graphs now contain all data points I meant to collect. 
- Have only run small test

