### PR TITLE
increases the version

### DIFF
--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	name       = "influxdb"
-	version    = 19
+	version    = 20
 	pluginType = plugin.PublisherPluginType
 	maxInt64   = ^uint64(0) / 2
 


### PR DESCRIPTION
The version needs to be revd.  

- The leading slash on a namespace was removed when publishing with 'isMultiFields' set to `true`.  This is to avoid Grafana interpreting the measurement name as a regex (due to the leading slash).