### PR TITLE
Upgrade plugin to recent version of plugin-lib-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 8bd0c4c7aad81d92fba50ee6eafd7690de026fc2b9acaee22d25df03ded2c13a
-updated: 2017-03-27T10:41:45.899652789+02:00
+updated: 2017-07-07T14:51:45.914459721+02:00
 imports:
 - name: github.com/golang/protobuf
   version: 888eb0692c857ec880338addf316bd662d5e630e
@@ -12,14 +12,16 @@ imports:
   - models
   - pkg/escape
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: 8ae21e8f72cb1740171073d496a6b7f2cec5ca73
+  version: 25d0f6c1ebd320c49b1a8cb2c2b32c6091c43530
   subpackages:
   - v1/plugin
   - v1/plugin/rpc
 - name: github.com/julienschmidt/httprouter
   version: 6f3f3919c8781ce5c0509c83fffc887a7830c938
 - name: github.com/Sirupsen/logrus
-  version: 10f801ebc38b33738c9d17d50860f484a0988ff5
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: github.com/urfave/cli
+  version: d70f47eeca3afd795160003bc6e28b001d60c67c
 - name: golang.org/x/net
   version: 154d9f9ea81208afed560f4cf27b4860c8ed1904
   subpackages:

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	Name       = "influxdb"
-	Version    = 23
+	Version    = 24
 	PluginType = "publisher"
 	maxInt64   = ^uint64(0) / 2
 	separator  = "\U0001f422"


### PR DESCRIPTION
Allow using plugin standalone on a dedicated host with a proper domain-bound TLS certificate.

Summary of changes:
- upgrade dependency to snap-plugin-lib-go 

How to verify it (testing with [psutil collector plugin](https://github.com/intelsdi-x/snap-plugin-collector-psutil)):
1. Acquire access to domain names. You may try aliasing loopback address in config file `/etc/hosts`.
1. Obtain test TLS certificates. For a local test you may see [SETUP_TLS_CERTIFICATES.md](/intelsdi-x/snap/blob/master/docs/SETUP_TLS_CERTIFICATES.md#obtaining-self-signed-certificates) in snap repository. Be sure to specify desired domain names instead of `localhost`.
1. Start snap with TLS certificates:
```
snapteld -t 0 -l 1 --tls-cert=/tmp/daemon.example.net-cli.crt --tls-key=/tmp/daemon.example.net-cli.key --ca-cert-paths=/tmp/example.net-ca.crt
```
1. Load necessary plugins:
```
./snap-plugin-collector-psutil --stand-alone --stand-alone-port 8281 --addr collectors.example.net --tls --cert-path /tmp/collectors.example.net-srv.crt --key-path /tmp/collectors.example.net-srv.key --root-cert-paths /tmp/example.net-ca.crt
./snap-plugin-publisher-influxdb --stand-alone --stand-alone-port 8381 --addr collectors.example.net --tls --cert-path /tmp/collectors.example.net-srv.crt --key-path /tmp/collectors.example.net-srv.key --root-cert-paths /tmp/example.net-ca.crt
snaptel plugin load http://collectors.example.net:8281
snaptel plugin load http://collectors.example.net:8381
```
1. Start example [influxdb task](https://github.com/intelsdi-x/snap-plugin-publisher-influxdb/blob/master/examples/tasks/psutil-influxdb-http.yml) (replace INFLUXDB_HOST for actual influxdb hostname).
1. Watch result:
`snaptel task watch <TASK_ID>`

Testing done:
- developer tests

