### PR TITLE
Fixes #136 and updates medium test

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,25 +1,27 @@
 hash: 8bd0c4c7aad81d92fba50ee6eafd7690de026fc2b9acaee22d25df03ded2c13a
-updated: 2017-03-27T10:41:45.899652789+02:00
+updated: 2017-07-17T10:10:01.101636431+02:00
 imports:
 - name: github.com/golang/protobuf
   version: 888eb0692c857ec880338addf316bd662d5e630e
   subpackages:
   - proto
 - name: github.com/influxdata/influxdb
-  version: b869607dc206cc58e63718ca72ea08293b987a0e
+  version: 4244d0e0536be53aab18160cd57e59190d57a693
   subpackages:
   - client/v2
   - models
   - pkg/escape
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: 8ae21e8f72cb1740171073d496a6b7f2cec5ca73
+  version: a8b9252d1c8305deb3c24495f1e9ce26607fcbd7
   subpackages:
   - v1/plugin
   - v1/plugin/rpc
 - name: github.com/julienschmidt/httprouter
-  version: 6f3f3919c8781ce5c0509c83fffc887a7830c938
+  version: 975b5c4c7c21c0e3d2764200bf2aa8e34657ae6e
 - name: github.com/Sirupsen/logrus
-  version: 10f801ebc38b33738c9d17d50860f484a0988ff5
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: github.com/urfave/cli
+  version: 4b90d79a682b4bf685762c7452db20f2a676ecb2
 - name: golang.org/x/net
   version: 154d9f9ea81208afed560f4cf27b4860c8ed1904
   subpackages:
@@ -30,7 +32,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: afadfcc7779c1f4db0f6f6438afcb108d9c9c7cd
+  version: 4cd6d1a821c7175768725b55ca82f14683a29ea4
   subpackages:
   - unix
 - name: google.golang.org/grpc

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	Name       = "influxdb"
-	Version    = 23
+	Version    = 25
 	PluginType = "publisher"
 	maxInt64   = ^uint64(0) / 2
 	separator  = "\U0001f422"

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -236,6 +236,8 @@ func (ip *InfluxPublisher) Publish(metrics []plugin.Metric, pluginConfig plugin.
 			if v > maxInt64 {
 				log.Errorf("Overflow during conversion uint64 to int64, value after conversion to int64: %d, desired uint64 value: %d ", data, v)
 			}
+
+			m.Data = data
 		}
 
 		if !isMultiFields {

--- a/influxdb/influxdb_medium_test.go
+++ b/influxdb/influxdb_medium_test.go
@@ -88,7 +88,7 @@ func tests(scheme string, config plugin.Config) {
 	tags := map[string]string{"zone": "red"}
 	mcfg := map[string]interface{}{"field": "abc123"}
 
-	Convey(" Publish integer metric via "+scheme, func() {
+	Convey("Publish integer metric via "+scheme, func() {
 		metrics := []plugin.Metric{
 			{
 				Namespace: plugin.NewNamespace("foo"),
@@ -112,6 +112,36 @@ func tests(scheme string, config plugin.Config) {
 				Tags:      tags,
 				Unit:      "someunit",
 				Data:      3.141,
+			},
+		}
+		err := ip.Publish(metrics, config)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Publish uint64 metric via "+scheme, func() {
+		metrics := []plugin.Metric{
+			{
+				Namespace: plugin.NewNamespace("uin"),
+				Timestamp: time.Now(),
+				Config:    mcfg,
+				Tags:      tags,
+				Unit:      "someunit",
+				Data:      uint64(123),
+			},
+		}
+		err := ip.Publish(metrics, config)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Publish larger than uint64 metric via "+scheme, func() {
+		metrics := []plugin.Metric{
+			{
+				Namespace: plugin.NewNamespace("lar"),
+				Timestamp: time.Now(),
+				Config:    mcfg,
+				Tags:      tags,
+				Unit:      "someunit",
+				Data:      ^uint64(0)/2 + 1,
 			},
 		}
 		err := ip.Publish(metrics, config)


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
(1) Fixes #136 -> Integers written to InfluxDB as strings
(2) Update medium test, increase coverage
(3) Added updated glide.lock and changed plugin version
-

Summary of changes:
-
- assign new value of `data` to `m.Data` even when variable `isMultiFields` equals `true`,
- update medium test in order to cover new changes
- added new version of glide.lock
- changed plugin version to 25


How to verify it:
-


- execute following command on database:
```
> show field keys
name: intel/psutil/load
fieldKey fieldType
-------- ---------
load1    float
load15   float
load5    float


name: intel/psutil/vm
fieldKey  fieldType
--------  ---------
available integer
free      integer
used      integer
```
In this case each of these fields: "available", "free" and "used", should be integer type (not string) 

- check simple SQL commands like this one below (but use no aggregation functions):
```
> select "available" from "intel/psutil/vm" where time > now() - 30s
name: intel/psutil/vm
time                available
----                ---------
1499952370682845187 27817246720
1499952372683285655 27817250816
1499952374683520347 27818987520
1499952376683803610 27819114496
1499952378683722739 27819831296
1499952380684008542 27819347968
1499952382684105525 27819220992
1499952384684443269 27818713088
1499952386685140106 27818872832
1499952388684883293 27817971712
1499952390685255954 27817725952
1499952392685351956 27818012672
1499952394685344972 27817287680
1499952396685525295 27816398848
1499952398685641788 27815448576

```

- execute following command to check whether aggregation function works :
```
> select mean("available") from "intel/psutil/vm" where time > now() - 30s group by time(10s)
name: intel/psutil/vm
time                mean
----                ----
1499952370000000000 2.7819472896e+10
1499952380000000000 2.78188253184e+10
1499952390000000000 2.78169747456e+10
1499952400000000000 2.7816259584e+10

```
Output should be similar to this one, additionally there should be no errors.

Testing done:
-
- small tests passed
- medium tests passed
