### PR TITLE
Fixes #114 - solved problem with medium test

### DIFF
--- a/scripts/medium.sh
+++ b/scripts/medium.sh
@@ -15,7 +15,6 @@ __proj_name="$(basename $__proj_dir)"
 export INFLUXDB_VERSION="${INFLUXDB_VERSION:-"1.0"}"
 export PLUGIN_SRC="${__proj_dir}"
 
-export GOLANGVER=${GOLANGVER:-"go1.7.4"}
 
 TEST_TYPE="${TEST_TYPE:-"medium"}"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,6 +30,20 @@ set -o pipefail
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 __proj_dir="$(dirname "$__dir")"
 
+export GOLANGVER=${GOLANGVER:-"go1.7.4"}
+
+# Remove existing containers
+if [ "$(docker ps -q -f "name=/golang_${GOLANGVER}\b")" ]; then 
+        echo -n "Removing old container (golang_${GOLANGVER}) ... "        
+        docker rm -f golang_${GOLANGVER}         
+fi
+
+if [ "$(docker ps -q -f 'name=/influxdb\b')" ]; then 
+        echo -n "Removing old container (influxdb) ... "   
+        docker rm -f influxdb          
+fi
+
+
 # shellcheck source=scripts/common.sh
 . "${__dir}/common.sh"
 


### PR DESCRIPTION
Fixes #114  - Medium test should cleanup containers after execution
-
Problem: 
> If the medium test fails, the docker-compose containers remain running, and the test will fail again during next execution.

Summary of changes:
- 

- now if the medium test fails, test will not fail again during next execution; because when the medium test starts, it is checked whether there are old containers from previous test and if so, they are removed

How to verify it:
-
- run the medium test with `make test-medium`
- during testing block network connection (disconnect from the Internet)
**INFO**: Sometimes test will not end even though, so you should kill it manually (ex. Ctrl-C)
- check whether there are still running containers from this last test
```
$ docker ps
CONTAINER ID        IMAGE                 COMMAND                  CREATED             STATUS              PORTS                          NAMES
25b0f94a6eac        intelsdi/gvm:latest   "/bin/sh -c 'sleep 10"   34 seconds ago      Up 33 seconds                                      golang_go1.7.4
cca67ab5b390        tutum/influxdb        "/run.sh"                35 seconds ago      Up 33 seconds       8083/tcp, 4444/udp, 8086/tcp   influxdb
8757ad326836        influxdb:1.2.4        "/entrypoint.sh influ"   6 days ago          Up 6 days           8086/tcp                       modest_morse
ae3bcc8c7bf0        influxdb:1.2.4        "/entrypoint.sh influ"   6 days ago          Up 6 days           0.0.0.0:8086->8086/tcp         influxdb_dev

```
They should have names: `golang_go1.7.4` and `influxdb`.

- run the medium test again with 'make test-medium' and it should pass (there will be additional information about removing these old containers)

```
$ make test-medium 
bash -c "./scripts/test.sh medium"
Removing old container (golang_go1.7.4) ... golang_go1.7.4
Removing old container (influxdb) ... influxdb
2017-07-19 08:29:14 UTC [     info] skipping go test in following directories: -not -path "./.*" -not -path "*/_*" -not -path "./Godeps/*" -not -path "./vendor/*"
Creating influxdb
Creating golang_go1.7.4
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    43    0    17  100    26   3593   5495 --:--:-- --:--:-- --:--:--  6500
HTTP/1.1 200 OK
Connection: close
Content-Type: application/json
Request-Id: 5b9aae99-6c5c-11e7-8001-000000000000
X-Influxdb-Version: 1.0.0
Date: Wed, 19 Jul 2017 08:29:18 GMT
Transfer-Encoding: chunked

{"results":[{}]}
Installing go1.7.4 from binary source
Now using version go1.7.4
2017-07-19 08:29:38 UTC [     info] golang dependency tool: glide
2017-07-19 08:29:38 UTC [     info] ensuring glide is available
2017-07-19 08:29:44 UTC [     info] restoring dependency with glide
[INFO]	Downloading dependencies. Please wait...
[INFO]	--> Fetching github.com/influxdata/influxdb

... rest of the output from terminal was omitted! ...
```

Testing done:
-
- medium test passed (before and after next medium test was forced to fail)
- plugin is building
